### PR TITLE
Update README adapt to Rails 6 [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ $ bundle
 
 This gem provides a rack middleware `ActiveRecord::ConnectionAdapters::RefreshConnectionManagement` which disconnects all connections in each rack request, which results in refreshing all connections in each rack request. 
 
-### Rails 5
+### Rails 5 and Rails 6
 
-NOTE: activerecord-refresh_connection **does not work with puma, and webrick** server in rails 5.
+NOTE: activerecord-refresh_connection **does not work with puma, and webrick** server in rails 5 and rails 6.
 
 ```ruby
 # config/application.rb


### PR DESCRIPTION

First of all, thank you for developing a great gem

## Summary
In the change from rails5 to rails6,
There were no changes to the `ActiveRecord::Base.clear_all_connections!` and `ActiveRecord::Base.clear_active_connections!` ActiveRecord methods called in this gem.

See: https://github.com/rails/rails/blame/e00f9c8aaea3fbedc2d19926da4f4575c12f0aaa/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb

Therefore, I added to README that this gem works on rails6.

could you verification?