### PR TITLE
Support Rails 6 multiple database connections.

### DIFF
--- a/lib/activerecord-refresh_connection/active_record/connection_adapters/refresh_connection_management.rb
+++ b/lib/activerecord-refresh_connection/active_record/connection_adapters/refresh_connection_management.rb
@@ -66,12 +66,14 @@ module ActiveRecord
           ActiveRecord::Base.connection_handlers.each_value do |handler|
             handler.connection_pool_list.each(&:disconnect!)
           end
+          ActiveRecord::Base.clear_all_connections!
         else
           ActiveRecord::Base.connection_handlers.each_value do |handler|
             handler.connection_pool_list.each do |pool|
               pool.release_connection if pool.active_connection? && !pool.connection.transaction_open?
             end
           end
+          ActiveRecord::Base.clear_active_connections!
         end
       end
 

--- a/lib/activerecord-refresh_connection/active_record/connection_adapters/refresh_connection_management.rb
+++ b/lib/activerecord-refresh_connection/active_record/connection_adapters/refresh_connection_management.rb
@@ -30,10 +30,22 @@ module ActiveRecord
       private
 
       def clear_connections
-        if should_clear_all_connections?
-          ActiveRecord::Base.clear_all_connections!
+        if ActiveRecord::VERSION::MAJOR >= 6
+          if should_clear_all_connections?
+            ActiveRecord::Base.connection_handlers.each_value do |connection_handler|
+              connection_handler.clear_all_connections!
+            end
+          else
+            ActiveRecord::Base.connection_handlers.each_value do |connection_handler|
+              connection_handler.clear_active_connections!
+            end
+          end
         else
-          ActiveRecord::Base.clear_active_connections!
+          if should_clear_all_connections?
+            ActiveRecord::Base.clear_all_connections!
+          else
+            ActiveRecord::Base.clear_active_connections!
+          end
         end
       end
 

--- a/lib/activerecord-refresh_connection/active_record/connection_adapters/refresh_connection_management.rb
+++ b/lib/activerecord-refresh_connection/active_record/connection_adapters/refresh_connection_management.rb
@@ -2,11 +2,14 @@ module ActiveRecord
   module ConnectionAdapters
     class RefreshConnectionManagement
       DEFAULT_OPTIONS = {max_requests: 1}
+      AR_VERSION_6_1 = "6.1".freeze
+      AR_VERSION_6_0 = "6.0".freeze
 
       def initialize(app, options = {})
         @app = app
         @options = DEFAULT_OPTIONS.merge(options)
         @mutex = Mutex.new
+        @ar_version = ActiveRecord.gem_version.to_s
 
         reset_remain_count
       end
@@ -30,22 +33,64 @@ module ActiveRecord
       private
 
       def clear_connections
-        if ActiveRecord::VERSION::MAJOR >= 6
-          if should_clear_all_connections?
-            ActiveRecord::Base.connection_handlers.each_value do |connection_handler|
-              connection_handler.clear_all_connections!
-            end
+        if @ar_version >= AR_VERSION_6_1
+          if legacy_connection_handling?
+            clear_legacy_compatible_connections
           else
-            ActiveRecord::Base.connection_handlers.each_value do |connection_handler|
-              connection_handler.clear_active_connections!
-            end
+            clear_all_roles_connections
+          end
+        elsif @ar_version >= AR_VERSION_6_0
+          clear_legacy_compatible_connections
+        else
+          clear_legacy_connections
+        end
+      end
+
+      def legacy_connection_handling?
+        begin
+          ActiveRecord::Base.legacy_connection_handling
+        rescue NoMethodError
+          false
+        end
+      end
+
+      def all_roles
+        roles = []
+        ActiveRecord::Base.connection_handler.instance_variable_get(:@owner_to_pool_manager).each_value do |pool_manager|
+          roles.concat(pool_manager.role_names)
+        end
+        roles.uniq
+      end
+
+      def clear_all_roles_connections
+        if should_clear_all_connections?
+          all_roles.each do |role|
+            ActiveRecord::Base.clear_all_connections!(role)
           end
         else
-          if should_clear_all_connections?
-            ActiveRecord::Base.clear_all_connections!
-          else
-            ActiveRecord::Base.clear_active_connections!
+          all_roles.each do |role|
+            ActiveRecord::Base.clear_active_connections!(role)
           end
+        end
+      end
+
+      def clear_legacy_compatible_connections
+        if should_clear_all_connections?
+          ActiveRecord::Base.connection_handlers.each_value do |connection_handler|
+            connection_handler.clear_all_connections!
+          end
+        else
+          ActiveRecord::Base.connection_handlers.each_value do |connection_handler|
+            connection_handler.clear_active_connections!
+          end
+        end
+      end
+
+      def clear_legacy_connections
+        if should_clear_all_connections?
+          ActiveRecord::Base.clear_all_connections!
+        else
+          ActiveRecord::Base.clear_active_connections!
         end
       end
 


### PR DESCRIPTION
EN)
Fixed to disconnect all connection_handlers in ActiveRecord 6 and later versions.

JA)
ActiveRecord 6では `ActiveRecord::Base#clear_all_connections!` 及び `ActiveRecord::Base#clear_active_connections!` は `ActiveRecord::Base#default_connection_handler` に処理が移譲されるため、
単一のデータベース接続を扱う場合は正常に動作しますが、複数のデータベース接続を扱う場合はdefault_connection_handler以外のconnection_handlerの接続が切れません。
 (多くの場合default_connection_handlerはPrimaryデータベース, それ以外のconnection_handlerはReplicaデータベースへ接続されています) 

`ActiveRecord::Base#connection_handlers` はActiveRecord 6で追加されたため、バージョン6以降とそれ以前で処理を分岐し、複数のデータベース接続においてもコネクションを切断出来るよう修正しました。
